### PR TITLE
Support `[P` escape (delete character)

### DIFF
--- a/fixtures/ansi-codes.js
+++ b/fixtures/ansi-codes.js
@@ -46,7 +46,7 @@ exports.ansiCompatible = {
 	'[0J': ['Same'],
 	'[2J': ['Erase entire screen'],
 	'[P' : ['Delete character'],
-	'[0P': ['Same'],
+	'[0P': ['Delete character (0P)'],
 	'[2P': ['Delete 2 characters'],
 
 	'(A': ['United Kingdom (UK) (Character Set G0)'],

--- a/fixtures/ansi-codes.js
+++ b/fixtures/ansi-codes.js
@@ -45,7 +45,7 @@ exports.ansiCompatible = {
 	'[J': ['Erase from cursor to end of screen'],
 	'[0J': ['Same'],
 	'[2J': ['Erase entire screen'],
-	'[P' : ['Delete charecter'],
+	'[P' : ['Delete character'],
 	'[0P': ['Same'],
 	'[2P': ['Delete 2 characters'],
 

--- a/fixtures/ansi-codes.js
+++ b/fixtures/ansi-codes.js
@@ -45,6 +45,9 @@ exports.ansiCompatible = {
 	'[J': ['Erase from cursor to end of screen'],
 	'[0J': ['Same'],
 	'[2J': ['Erase entire screen'],
+	'[P' : ['Delete charecter'],
+	'[0P': ['Same'],
+	'[2P': ['Delete 2 characters'],
 
 	'(A': ['United Kingdom (UK) (Character Set G0)'],
 	')A': ['United Kingdom (UK) (Character Set G1)'],

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 module.exports = function () {
-	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-RZcf-nqry=><]/g;
+	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]/g;
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 module.exports = function () {
-	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+	return /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-RZcf-nqry=><]/g;
 };


### PR DESCRIPTION
Hello.

I worked with bash output and faced with the next line:
`\r\u001b[C\u001b[C\u001b[2Pls`

There is `[2P` escape code that means "delete two characters".
As I can see for now it doesn't supported. 
Maybe there is a strong reason for skipping "P" char in the current regex. If so please explain my why :)