### PR TITLE
Use last XO & AVA versions that supports Node.js 0.10 and 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "pattern"
   ],
   "devDependencies": {
-    "ava": "*",
-    "xo": "*"
+    "ava": "0.17.0",
+    "xo": "0.16.0"
   },
   "xo": {
     "rules": {


### PR DESCRIPTION
Hello.

The newest xo version dropped support for Node v0.10 and v0.12. New ava version is going to do the same. It means, all the pull requests will fail on travis-ci