### PR TITLE
Support urxvt escapes

### DIFF
--- a/fixtures/ansi-codes.js
+++ b/fixtures/ansi-codes.js
@@ -212,3 +212,20 @@ exports.otherCode = new Map([
 	['3n', ['Response: terminal is not OK', 'DSR']],
 	['6n', ['Get cursor position', 'DSR']]
 ]);
+
+// urxvt escapes
+exports.urxvt = new Map([
+	['[5~', ['URxvt.keysym.Prior']],
+	['[6~', ['URxvt.keysym.Next']],
+	['[7~', ['URxvt.keysym.Home']],
+	['[8~', ['URxvt.keysym.End']],
+	['[A', ['URxvt.keysym.Up']],
+	['[B', ['URxvt.keysym.Down']],
+	['[C', ['URxvt.keysym.Right']],
+	['[D', ['URxvt.keysym.Left']],
+	['[3;5;5t', ['URxvt.keysym.C-M-q']],
+	['[3;5;606t', ['URxvt.keysym.C-M-y']],
+	['[3;1605;5t', ['URxvt.keysym.C-M-e']],
+	['[3;1605;606t', ['URxvt.keysym.C-M-c']],
+	[']710;9x15bold\x07', ['URxvt.keysym.font']]
+]);

--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
 'use strict';
-module.exports = () => (/[\u001B\u009B][[()#;?]*(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-nqry=><]/g);
+
+// eslint-disable-next-line no-control-regex
+module.exports = () => /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z0-9]*(?:;[a-zA-Z0-9]*)*)?\x07)|(?:(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-ntqry=><~]))/g;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 'use strict';
 
-// eslint-disable-next-line no-control-regex
-module.exports = () => /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z0-9]*(?:;[a-zA-Z0-9]*)*)?\x07)|(?:(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-ntqry=><~]))/g;
+module.exports = () => {
+	const pattern = [
+		'[\\u001b\\u009b][[\\]()#;?]*(?:(?:(?:[a-zA-Z0-9]*(?:;[a-zA-Z0-9]*)*)?\\x07)',
+		'(?:(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-ntqry=><~]))'
+	].join('|');
+
+	return new RegExp(pattern, 'g');
+};


### PR DESCRIPTION
Fixes chalk/strip-ansi#10.

As I mentioned over there these are annoyingly different escape codes.

This PR is a massive performance hit since it has to do backtracking on almost every match. There's no other way to support it, though.