### PR TITLE
Add a typings file for typescript users.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'ansi-regex' {
+    export default let _:RegExp;
+}
+

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "view-supported": "node fixtures/view-codes.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
+  "typings": "index.d.ts",
   "keywords": [
     "ansi",
     "styles",


### PR DESCRIPTION
This adds a index.d.ts file so that you can do 
```
import ansiRegexp from "ansi-regex";
ansiRegexp.test("...");
```
in typescript instead of having a local typings file or doing
```
const ansiRegexp: RegExp = require('ansi-regex');
```
Note that the problem with the latter approach is that you need to guess the type returned by require.  In the former approach, the npm package will tell you what the type is, reducing accidental mis-types in Typescript.
