### PR TITLE
feat: support both CJS and ESM syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/iron
       - run: npm install
+      - run: npm build
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: lts/iron
       - run: npm install
-      - run: npm build
+      - run: npm run build
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,5 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm install
       - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules
 yarn.lock
+
+# bundle
+index.cjs*
+index.js*
+index.d.ts

--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-export default function ansiRegex({onlyFirst = false} = {}) {
-	const pattern = [
-		'[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
-		'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
-	].join('|');
-
-	return new RegExp(pattern, onlyFirst ? undefined : 'g');
-}

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,11 @@
 export interface Options {
-    /**
+	/**
     Match only the first ANSI escape.
 
     @default false
     */
-    readonly onlyFirst?: boolean;
+	readonly onlyFirst?: boolean;
 }
-
 
 /**
 Regular expression for matching ANSI escape codes.
@@ -31,11 +30,11 @@ ansiRegex().test('cake');
 //=> ['\u001B]8;;https://github.com\u0007', '\u001B]8;;\u0007']
 ```
 */
-export default function ansiRegex({ onlyFirst = false }: Options = {}) {
-    const pattern = [
-        '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
-        '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
-    ].join('|');
+export default function ansiRegex({onlyFirst = false}: Options = {}) {
+	const pattern = [
+		'[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+		'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
+	].join('|');
 
-    return new RegExp(pattern, onlyFirst ? undefined : 'g');
+	return new RegExp(pattern, onlyFirst ? undefined : 'g');
 }

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,12 @@
 export interface Options {
-	/**
-	Match only the first ANSI escape.
+    /**
+    Match only the first ANSI escape.
 
-	@default false
-	*/
-	readonly onlyFirst: boolean;
+    @default false
+    */
+    readonly onlyFirst?: boolean;
 }
+
 
 /**
 Regular expression for matching ANSI escape codes.
@@ -30,4 +31,11 @@ ansiRegex().test('cake');
 //=> ['\u001B]8;;https://github.com\u0007', '\u001B]8;;\u0007']
 ```
 */
-export default function ansiRegex(options?: Options): RegExp;
+export default function ansiRegex({ onlyFirst = false }: Options = {}) {
+    const pattern = [
+        '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+        '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
+    ].join('|');
+
+    return new RegExp(pattern, onlyFirst ? undefined : 'g');
+}

--- a/package.json
+++ b/package.json
@@ -11,16 +11,34 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": "./index.js",
+	"source": "./index.ts",
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"types": "./index.d.ts",
+	"exports": {
+		".": {
+			"default": "./index.cjs",
+			"node": "./index.cjs",
+			"require": "./index.cjs",
+			"import": "./index.js",
+			"types": "./index.d.ts"
+		},
+		"./package.json": "./package.json"
+	},
 	"engines": {
 		"node": ">=12"
 	},
 	"scripts": {
+		"build": "lbundle",
+		"pretest": "lbundle",
 		"test": "xo && ava && tsd",
 		"view-supported": "node fixtures/view-codes.js"
 	},
 	"files": [
 		"index.js",
+		"index.js.map",
+		"index.cjs",
+		"index.cjs.map",
 		"index.d.ts"
 	],
 	"keywords": [
@@ -53,6 +71,7 @@
 	"devDependencies": {
 		"ansi-escapes": "^5.0.0",
 		"ava": "^3.15.0",
+		"lbundle": "^1.1.2",
 		"tsd": "^0.14.0",
 		"xo": "^0.38.2"
 	}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 	},
 	"scripts": {
 		"build": "lbundle",
-		"pretest": "lbundle",
 		"test": "xo && ava && tsd",
 		"view-supported": "node fixtures/view-codes.js"
 	},

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	},
 	"scripts": {
 		"build": "lbundle",
-		"test": "xo && ava && tsd",
+		"lint": "xo ./fixtures/* ./index.test-d.ts ./index.ts ./test.js",
+		"test": "npm run lint && ava && tsd",
 		"view-supported": "node fixtures/view-codes.js"
 	},
 	"files": [


### PR DESCRIPTION
I have an issue with both of this and `strip-ansi` where both migrated to ESM without supporting both syntax,

I used a simple fast library to bundle the code