### PR TITLE
Support colon separated parameters to control sequences

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ export default function ansiRegex({onlyFirst = false} = {}) {
 	const ST = '(?:\\u0007|\\u001B\\u005C|\\u009C)';
 	const pattern = [
 		`[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?${ST})`,
-		'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
+		'(?:(?:\\d{1,4}(?:[;:]\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
 	].join('|');
 
 	return new RegExp(pattern, onlyFirst ? undefined : 'g');

--- a/test.js
+++ b/test.js
@@ -61,6 +61,11 @@ test('match "change icon name and window title" in string', t => {
 	t.is('\u001B]0;sg@tota:~/git/\u0007\u001B[01;32m[sg@tota\u001B[01;37m misc-tests\u001B[01;32m]$'.match(ansiRegex())[0], '\u001B]0;sg@tota:~/git/\u0007');
 });
 
+test('match colon separated sequence arguments', t => {
+	t.regex('\u001B[38:2:68:68:68:48:2:0:0:0m', ansiRegex());
+	t.is('\u001B[38:2:68:68:68:48:2:0:0:0m'.match(ansiRegex())[0], '\u001B[38:2:68:68:68:48:2:0:0:0m');
+});
+
 // Testing against extended codes (excluding codes ending in 0-9)
 for (const [codeSetKey, codeSetValue] of Object.entries(ansiCodes)) {
 	for (const [code, codeInfo] of codeSetValue) {


### PR DESCRIPTION
This tries to fix #59. I'm not sure if mixing of `;`'s and `:`'s should be allowed or if all control sequences support `:` separated params. Different terminals appear to behave differently :sweat_smile: 